### PR TITLE
Fix for breaking on deadlines.

### DIFF
--- a/src/main/java/org/kritiniyoga/karmayoga/Schedule.java
+++ b/src/main/java/org/kritiniyoga/karmayoga/Schedule.java
@@ -2,6 +2,7 @@ package org.kritiniyoga.karmayoga;
 
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
+import io.vavr.collection.Seq;
 import io.vavr.control.Validation;
 import lombok.Value;
 import org.kritiniyoga.karmayoga.validators.ScheduleValidator;
@@ -16,14 +17,22 @@ public class Schedule {
         this.slot = slot;
     }
 
-    public static Schedule createSchedule(TimeSlot slot, Task task) {
+    private static Validation<Seq<String>, Schedule> validatedSchedule(TimeSlot slot, Task task) {
         Tuple2<Task, TimeSlot> taskSlotTuple = Tuple.of(task, slot);
-        var vResult = Validation
+        return Validation
             .combine(
                 ScheduleValidator.checkSlotIsBeforeTaskEnds(taskSlotTuple),
                 ScheduleValidator.checkTaskFitsSlot(taskSlotTuple))
             .ap((result1, result2) -> new Schedule(task, slot));
+    }
+
+    public static Schedule createScheduleOrFail(TimeSlot slot, Task task) {
+        Validation<Seq<String>, Schedule> vResult = validatedSchedule(slot, task);
         return vResult
             .getOrElseThrow(() -> new IllegalArgumentException(vResult.getError().toString()));
+    }
+
+    public static boolean areValidScheduleParams(TimeSlot slot, Task task) {
+        return validatedSchedule(slot, task).isValid();
     }
 }

--- a/src/main/java/org/kritiniyoga/karmayoga/allocators/SampleAllocator.java
+++ b/src/main/java/org/kritiniyoga/karmayoga/allocators/SampleAllocator.java
@@ -25,7 +25,7 @@ public class SampleAllocator implements Allocator {
     private Schedule createSchedules(Tuple2<Optional<TimeSlot>,? extends Seq<Task>> optionalTuple2) {
         Task task = selectFirstTaskByPriorityAndEstimate(optionalTuple2._2);
         TimeSlot slot = optionalTuple2._1.get();
-        return Schedule.createSchedule(slot, task);
+        return Schedule.createScheduleOrFail(slot, task);
     }
 
     private boolean hasEmptySlot(Tuple2<Optional<TimeSlot>, ? extends Seq<Task>> slotTaskTuple) {

--- a/src/main/java/org/kritiniyoga/karmayoga/allocators/SimpleFirstFit.java
+++ b/src/main/java/org/kritiniyoga/karmayoga/allocators/SimpleFirstFit.java
@@ -16,7 +16,7 @@ public class SimpleFirstFit implements Allocator {
 
     private Tuple2<List<Schedule>, TreeSet<TimeSlot>> directlyAllocate(Tuple2<List<Schedule>, TreeSet<TimeSlot>> scheduleSlotTuple, TimeSlot currentSlot, Task task) {
         return Tuple.of(
-            scheduleSlotTuple._1.append(Schedule.createSchedule(currentSlot, task)),
+            scheduleSlotTuple._1.append(Schedule.createScheduleOrFail(currentSlot, task)),
             scheduleSlotTuple._2
         );
     }
@@ -28,7 +28,7 @@ public class SimpleFirstFit implements Allocator {
     private Tuple2<List<Schedule>, TreeSet<TimeSlot>> splitSlotAndAllocate(Tuple2<List<Schedule>, TreeSet<TimeSlot>> scheduleSlotTuple, TimeSlot currentSlot, Task task) {
         List<TimeSlot> splits = currentSlot.split(findSplitPoint(currentSlot, task));
         return Tuple.of(
-            scheduleSlotTuple._1.append(Schedule.createSchedule(splits.get(0), task)),
+            scheduleSlotTuple._1.append(Schedule.createScheduleOrFail(splits.get(0), task)),
             scheduleSlotTuple._2.add(splits.get(1))
         );
     }
@@ -45,13 +45,9 @@ public class SimpleFirstFit implements Allocator {
         }
     }
 
-    private boolean isTaskFittingSlot(Task task, TimeSlot timeSlot) {
-        return timeSlot.length().compareTo(task.getEstimate()) >= 0;
-    }
-
     private Tuple2<List<Schedule>, TreeSet<TimeSlot>> applyFirstFitAlgorithm(Tuple2<List<Schedule>, TreeSet<TimeSlot>> scheduleSlotTuple, Task task) {
         return scheduleSlotTuple._2
-            .find(timeSlot -> isTaskFittingSlot(task, timeSlot))
+            .find(timeSlot -> Schedule.areValidScheduleParams(timeSlot, task))
             .map(timeSlot -> allocateTaskToSlot(scheduleSlotTuple, timeSlot, task))
             .getOrElse(scheduleSlotTuple);
     }

--- a/src/test/java/org/kritiniyoga/karmayoga/SchedulingBasics.java
+++ b/src/test/java/org/kritiniyoga/karmayoga/SchedulingBasics.java
@@ -22,7 +22,7 @@ public class SchedulingBasics {
             deadline.plus(2, ChronoUnit.HOURS));
 
         assertThrows(IllegalArgumentException.class,
-            () -> Schedule.createSchedule(slotBeyondDeadline, task));
+            () -> Schedule.createScheduleOrFail(slotBeyondDeadline, task));
     }
 
     @Test
@@ -33,6 +33,6 @@ public class SchedulingBasics {
             now.plus(1, ChronoUnit.HOURS));
 
         assertThrows(IllegalArgumentException.class,
-            () -> Schedule.createSchedule(smallerSlot, task));
+            () -> Schedule.createScheduleOrFail(smallerSlot, task));
     }
 }


### PR DESCRIPTION
* Rename createSchedule method to createScheduleOrFail as it throws error when it fails.

* Add Schedule.areValidScheduleParams method to check for TimeSlot and Task validity for schedules before attempting to create for safety.

resolves #16 