### PR TITLE
Update README with labels for ci build status and license.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Karmayoga :calendar:
 
+![CircleCI](https://img.shields.io/circleci/build/github/octetful/karmayoga?token=fe220cb4c9b12e2ecee443271b464bc80aa780d2)
+![GitHub](https://img.shields.io/github/license/octetful/karmayoga)
+
 Karmayoga is a java software for Task Organization with a focus on humans :family: (not machines).
 
 Originally started with the goal of building a simple Java library with an opinionated view of automatic human task organization as a fitting problem, the project aimed to solve daily planning using simple algorithm implementations.
@@ -7,10 +10,6 @@ Originally started with the goal of building a simple Java library with an opini
 Currently, we plan to extend it to be a fully usable software, integrated with online Calendars, and with possible future UI extensions in scope.
 
 Please refer to the [ADR sections](./docs/adr/index.md) for details on changes to the architecture and major directions of the project.
-
-
-### Status
-* Tests: [![CircleCI](https://circleci.com/gh/octetful/karmayoga/tree/master.svg?style=svg&circle-token=fe220cb4c9b12e2ecee443271b464bc80aa780d2)](https://circleci.com/gh/octetful/karmayoga/tree/master)
 
 
 


### PR DESCRIPTION
# Problem Context
Current README file doesn't have proper shield badges for build status, license etc.

# Proposed Changes
This PR adds shield status badges to the README file for:
- license
- Circle CI build status

# Meta
| Q             | A                                                                                      |
| ------------- | -------------------------------------------------------------------------------------- |
| Issue Type    | Documentation                                             |                                                                                |
| Issues        | Fix #30  <!-- prefix each issue number with "Fix #", if any. Remove if it does not --> |
| Docs Updated | y |
| ADR Updated | n |




