### PR TITLE
Add basic springboot adapter.

### DIFF
--- a/rest-api/build.gradle
+++ b/rest-api/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'org.springframework.boot' version '2.4.4'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+    implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+    compileOnly 'org.projectlombok:lombok:1.18.12'
+    annotationProcessor 'org.projectlombok:lombok:1.18.12'
+    testCompile 'org.mockito:mockito-core:1.+'
+
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/rest-api/src/main/java/org/kritiniyoga/karmayoga/rest/Application.java
+++ b/rest-api/src/main/java/org/kritiniyoga/karmayoga/rest/Application.java
@@ -1,0 +1,13 @@
+package org.kritiniyoga.karmayoga.rest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/rest-api/src/main/java/org/kritiniyoga/karmayoga/rest/configurations/SwaggerConfiguration.java
+++ b/rest-api/src/main/java/org/kritiniyoga/karmayoga/rest/configurations/SwaggerConfiguration.java
@@ -1,0 +1,16 @@
+package org.kritiniyoga.karmayoga.rest.configurations;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfiguration {
+    @Bean
+    public Docket productApi() {
+        return new Docket(DocumentationType.SWAGGER_2).select()
+                .apis(RequestHandlerSelectors.basePackage("org.kritiniyoga.karmayoga.rest")).build();
+    }
+}

--- a/rest-api/src/main/resources/application.yml
+++ b/rest-api/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  profiles: default
+server:
+  port: 8080
+
+
+---
+spring:
+  profiles: development
+
+server:
+  port: 8080

--- a/rest-api/src/test/java/org/kritiniyoga/karmayoga/rest/ApplicationSmokeTest.java
+++ b/rest-api/src/test/java/org/kritiniyoga/karmayoga/rest/ApplicationSmokeTest.java
@@ -1,0 +1,12 @@
+package org.kritiniyoga.karmayoga.rest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ApplicationSmokeTest {
+    @Test
+    void contextLoads() {
+
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'karmayoga'
 include 'core'
+include 'rest-api'
 


### PR DESCRIPTION
# Problem Context
As Karmayoga was started initially as a task scheduling library, it lacked basic application modules, such as a restful api module with springboot.

# Proposed Changes
This PR adds a barebones restful api module with springboot web starter support.

# Meta
| Q             | A                                                                                      |
| ------------- | -------------------------------------------------------------------------------------- |
| Issue Type    | Feature                                           |                                                                                |
| Issues        | Fix #32  |
| Docs Updated | n |
| ADR Updated | n |




