### PR TITLE
Model aggregate ownership information in domain model.

### DIFF
--- a/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/entities/Schedule.java
+++ b/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/entities/Schedule.java
@@ -2,13 +2,16 @@ package org.kritiniyoga.karmayoga.core.domain.entities;
 
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import org.kritiniyoga.karmayoga.core.domain.values.TimeSlot;
 
 @Data
 @AllArgsConstructor
+@Builder(toBuilder = true)
 public class Schedule {
   UUID id;
   Task task;
   TimeSlot slot;
+  User owner;
 }

--- a/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/entities/Task.java
+++ b/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/entities/Task.java
@@ -16,4 +16,5 @@ public class Task {
   Priority priority;
   Duration estimate;
   Date deadline;
+  User owner;
 }

--- a/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/entities/User.java
+++ b/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/entities/User.java
@@ -1,0 +1,10 @@
+package org.kritiniyoga.karmayoga.core.domain.entities;
+
+import lombok.Data;
+
+@Data
+public class User {
+  String id;
+  String name;
+  String email;
+}

--- a/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/repositories/SchedulesRepository.java
+++ b/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/repositories/SchedulesRepository.java
@@ -8,7 +8,5 @@ import org.kritiniyoga.karmayoga.core.domain.values.TimeSlot;
 public interface SchedulesRepository {
   Seq<Schedule> fetchAllSchedules();
 
-  Seq<Schedule> fetchSchedulesInGivenSlot(TimeSlot slot);
-
   Schedule fetchById(Long id);
 }

--- a/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/repositories/TasksRepository.java
+++ b/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/repositories/TasksRepository.java
@@ -9,15 +9,5 @@ import org.kritiniyoga.karmayoga.core.domain.values.Priority;
 public interface TasksRepository {
   Seq<Task> fetchAllTasks();
 
-  Seq<Task> fetchTasksWithPriority(Priority priority);
-
-  Seq<Task> fetchTasksWithEstimate(Duration estimate);
-
-  Seq<Task> fetchTasksWithGivenDeadline(Date deadline);
-
-  Seq<Task> fetchTasksMatchingTitle(String title);
-
-  Seq<Task> fetchTasksMatchingNotes(String notes);
-
   Task fetchById(Long id);
 }

--- a/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/services/allocators/SimpleFirstFit.java
+++ b/core/src/main/java/org/kritiniyoga/karmayoga/core/domain/services/allocators/SimpleFirstFit.java
@@ -19,7 +19,7 @@ public class SimpleFirstFit implements Allocator {
       TimeSlot currentSlot, Task task
   ) {
     return Tuple.of(
-        scheduleSlotTuple._1.append(ScheduleFactory.createFromOrFail(currentSlot, task)),
+        scheduleSlotTuple._1.append(ScheduleFactory.createFromOrFail(currentSlot, task, task.getOwner())),
         scheduleSlotTuple._2
     );
   }
@@ -34,7 +34,7 @@ public class SimpleFirstFit implements Allocator {
   ) {
     List<TimeSlot> splits = currentSlot.split(findSplitPoint(currentSlot, task));
     return Tuple.of(
-        scheduleSlotTuple._1.append(ScheduleFactory.createFromOrFail(splits.get(0), task)),
+        scheduleSlotTuple._1.append(ScheduleFactory.createFromOrFail(splits.get(0), task, task.getOwner())),
         scheduleSlotTuple._2.add(splits.get(1))
     );
   }

--- a/core/src/test/java/org/kritiniyoga/karmayoga/core/domain/factories/SchedulingCreation.java
+++ b/core/src/test/java/org/kritiniyoga/karmayoga/core/domain/factories/SchedulingCreation.java
@@ -24,7 +24,7 @@ public class SchedulingCreation {
             deadline.plus(2, ChronoUnit.HOURS));
 
         assertThrows(IllegalArgumentException.class,
-            () -> ScheduleFactory.createFromOrFail(slotBeyondDeadline, task));
+            () -> ScheduleFactory.createFromOrFail(slotBeyondDeadline, task, task.getOwner()));
     }
 
     @Test
@@ -35,6 +35,6 @@ public class SchedulingCreation {
             now.plus(1, ChronoUnit.HOURS));
 
         assertThrows(IllegalArgumentException.class,
-            () -> ScheduleFactory.createFromOrFail(smallerSlot, task));
+            () -> ScheduleFactory.createFromOrFail(smallerSlot, task, task.getOwner()));
     }
 }


### PR DESCRIPTION
# Problem Context
The current domain model lacks any ownership information or mechanism. In a multiuser system, a sense of ownership for all business aggregates is essential.

# Proposed Changes
This PR introduces the following changes:
- Adds a `User` entity.
- Domain aggregates `Schedule` and `Task` now have owner information field.
- Assumes ownership retention between `Task` and `Schedule` objects.
- Removes unnecessary repsitory methods to make way for full CQRS query model seggregation.

# Meta
| Q             | A                                                                                      |
| ------------- | -------------------------------------------------------------------------------------- |
| Issue Type    |  Feature                                          |                                                                                |
| Issues        | Fix #40   |
| Docs Updated | n |
| ADR Updated | n |




